### PR TITLE
Add pkg.funding

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "url": "https://github.com/ryanve/ssv/issues"
   },
   "homepage": "https://github.com/ryanve/ssv#readme",
+  "funding": "https://github.com/sponsors/ryanve",
   "devDependencies": {
     "eslint": "^4.11.0"
   }


### PR DESCRIPTION
[`funding`](https://docs.npmjs.com/configuring-npm/package-json.html#funding) in `package.json` [introduced in 2019](https://github.com/npm/rfcs/blob/latest/accepted/0017-add-funding-support.md#implementation) goes with the [`npm fund`](https://docs.npmjs.com/cli-commands/fund.html) command

I put [my Github sponsor page](https://github.com/sponsors/ryanve)

👾 

