### PR TITLE
Speed up union

### DIFF
--- a/ssv.js
+++ b/ssv.js
@@ -54,7 +54,7 @@
   }
 
   function union(ssv, more) {
-    return uniq(concat(ssv, more))
+    return uniq(ssv + space + more)
   }
 
   function xor(left, right) {


### PR DESCRIPTION
- Avoids several function calls
- Avoids excess compacting
- Compresses 3 bytes smaller
- Speeds up methods that use `union` including `meet` and `xor`