### PR TITLE
Speed up uniq

### DIFF
--- a/ssv.js
+++ b/ssv.js
@@ -71,11 +71,12 @@
 
   function uniq(ssv) {
     ssv = split(ssv)
+    var n = 0
     var u = []
     var l = ssv.length
     outer:for (var i = 0; i < l; i++) {
-      for (var j = u.length; j--;) if (ssv[i] === u[j]) continue outer
-      u.push(ssv[i])
+      for (var j = n; j--;) if (ssv[i] === u[j]) continue outer
+      u[n++] = ssv[i]
     }
     return u.join(space)
   }


### PR DESCRIPTION
Faster because it avoids `.push` and `.length` in the loop