### PR TITLE
Still return early if all search is empty

### DIFF
--- a/ssv.js
+++ b/ssv.js
@@ -40,7 +40,7 @@
   }
 
   function all(ssv, search) {
-    return !diff(search, ssv)
+    return blank(search) || !diff(search, ssv)
   }
 
   function concat(ssv, more) {


### PR DESCRIPTION
Avoid behavior change from #50 for non-string first argument. Without returning blank searches early `all(null, "")` would error. Gotta wait to introduce that change till the next major version