### PR TITLE
Slate all inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,21 +80,21 @@ ssv.state({
 
 ## Static API
 
-### `ssv.all(SSV, SSV2)`
-- Test if <var>SSV</var> contains **all** <var>SSV2</var> values
+### `ssv.all(SSV="", search="")`
+- Test if SSV contains **all** <var>search</var> values
 - `@return` boolean
 
-### `ssv.any(SSV, SSV2)`
-- Test if <var>SSV</var> contains **any** <var>SSV2</var> values
+### `ssv.any(SSV="", search="")`
+- Test if SSV contains **any** <var>search</var> values
 - `@return` boolean
 
-### `ssv.at(SSV, index)`
+### `ssv.at(SSV="", index)`
 - Get the value at the specified <var>index</var>
 - Supports positive or negative <var>index</var>
 - `@return` string
 
-### `ssv.blank(SSV)`
-- Test if <var>SSV</var> has no values
+### `ssv.blank(SSV="")`
+- Test if SSV has no values
 - `true` for empty string or whitespace
 - `@return` boolean
 
@@ -102,54 +102,71 @@ ssv.state({
 - Remove excess whitespace from <var>SSV</var>
 - `@return` string
 
-### `ssv.concat(SSV, SSV2)`
+### `ssv.concat(SSV="", more="")`
 - Concatenate 2 SSV strings
 - `@return` string
 
-### `ssv.count(SSV)`
-- Count the number of values in <var>SSV</var>
+### `ssv.count(SSV="")`
+- Count SSV values
 - `@return` number
 
-### `ssv.diff(SSV, SSV2)`
+### `ssv.diff(left="", right="")`
 - Get the difference of 2 SSV strings (values in first not present in second)
 - `@return` string
 
-### `ssv.meet(SSV, SSV2)`
+### `ssv.meet(left="", right="")`
 - Get the intersection of 2 SSV strings (unique values present in both)
 - `@return` string
 
-### `ssv.need(SSV, SSV2)`
-- Complement <var>SSV</var> with needed values from <var>SSV2</var>
+### `ssv.need(SSV="", more="")`
+- Complement <var>set</var> with needed values from <var>more</var>
 - `@return` string
 
-### `ssv.split(SSV)`
+### `ssv.slate(anything="")`
+- Get SSV string from anything
+- Used internally to normalize inputs
+- Uses `typeof` to determine type
+  - `string` returns as is
+  - `number|boolean|bigint` coerce to string
+  - `object|function` delegates to `ssv.swoop`
+  - `undefined|symbol` return `""`
+- Messy whitespace remains messy
+- `@return` string
+
+### `ssv.split(set)`
 - Split <var>SSV</var> into compact array of values
 - `@return` array
 
-### `ssv.state(state={})`
+### `ssv.state(anything="")`
 - Get SSV string from <var>state</var> object or string
 - Useful for conditional classnames
 - `@return` string
 
-### `ssv.union(SSV, SSV2)`
+### `ssv.swoop(object={})`
+- Get SSV string from state object
+- Useful for conditional classnames object
+- Fast and loose
+- `@return` string
+
+### `ssv.union(left="", right="")`
 - Get the union of 2 SSV strings (unique values found in either)
 - `@return` string
 
-### `ssv.uniq(SSV)`
+### `ssv.uniq(set="")`
 - Get unique values found in <var>SSV</var>
 - `@return` string
 
-### `ssv.xor(SSV, SSV2)`
-- Get unique values found in either <var>SSV</var> or <var>SSV2</var> but not both
+### `ssv.xor(left="", right="")`
+- Get unique values found in either <var>left</var> or <var>right</var> but not both
 - `@return` string
 
 ## Chaining API
 
 Chaining offers all the static methods in chain syntax
 
-### `ssv(SSV="")`
+### `ssv(set="")`
 - Create an `ssv` object instance
-- <var>SSV</var> defaults to an empty string
+- <var>set</var> defaults to an empty string
 - `@return` object
 
 #### Non-string returns are direct

--- a/ssv.d.ts
+++ b/ssv.d.ts
@@ -1,19 +1,21 @@
 declare module ssv {
-  export function all(set: string, search: string): boolean;
-  export function any(set: string, search: string): boolean;
-  export function at(set: string, index: number): string;
-  export function blank(set: string): boolean;
-  export function compact(set: string): string;
-  export function need(set: string, more: string): string;
-  export function concat(set: string, more: string): string;
-  export function count(set: string): number;
-  export function diff(set: string, less: string): string;
-  export function meet(left: string, right: string): string;
-  export function split(set: string): string[];
-  export function state(state: object | string): string;
-  export function union(set: string, more: string): string;
-  export function uniq(set: string): string;
-  export function xor(left: string, right: string): string;
+  export function all(set: any, search: any): boolean;
+  export function any(set: any, search: any): boolean;
+  export function at(set: any, index: any): string;
+  export function blank(set: any): boolean;
+  export function compact(set: any): string;
+  export function concat(set: any, more: any): string;
+  export function count(set: any): number;
+  export function diff(set: any, less: any): string;
+  export function meet(left: any, right: any): string;
+  export function need(set: any, more: any): string;
+  export function split(set: any): string[];
+  export function slate(set: any): string;
+  export function state(set: any): string;
+  export function swoop(set: any): string;
+  export function union(set: any, more: any): string;
+  export function uniq(set: any): string;
+  export function xor(left: any, right: any): string;
 }
 
 declare module "ssv" {

--- a/test.js
+++ b/test.js
@@ -181,6 +181,8 @@ console.log("#meet tests passed")
 assert.strictEqual(ssv.state(""), "")
 assert.strictEqual(ssv.state(" "), "")
 assert.strictEqual(ssv.state({}), "")
+assert.strictEqual(ssv.state(Symbol()), "")
+assert.strictEqual(ssv.state(Symbol("ignore")), "")
 assert.strictEqual(ssv.state(ssv.state("mark")), "mark")
 assert.strictEqual(ssv.state(ssv.state(" tom ")), "tom")
 assert.strictEqual(ssv.state(ssv.state(" mark matt ")), "mark matt")
@@ -206,7 +208,7 @@ console.log("#state tests passed")
 assert.ok(ssv() instanceof ssv)
 assert.ok(ssv().$ === "")
 assert.ok(ssv(undefined).$ === "")
-assert.ok(ssv(null).$ === "null")
+assert.ok(ssv(null).$ === "")
 assert.ok(ssv("182").$ === "182")
 assert.ok(ssv(182).$ === "182")
 assert.ok(ssv().hasOwnProperty("$"))
@@ -226,6 +228,10 @@ assert.ok(ssv.prototype.split().length === 0)
 console.log("prototype tests passed")
 
 assert.ok(ssv().count() === 0)
+assert.ok(ssv([]).$ === "")
+assert.ok(ssv(true).$ === "true")
+assert.ok(ssv(false).$ === "false")
+assert.ok(ssv([,"blink"]).$ === "1")
 assert.ok(ssv("mark tom scott").any("mark"))
 assert.ok(ssv("mark tom scott").count() === 3)
 assert.ok(ssv("mark tom scott").diff("scott").count() === 2)
@@ -246,9 +252,37 @@ assert.ok(
 )
 assert.ok(
   ssv("mark tom scott")
-    .diff(ssv.state({ "tom scott": true }))
-    .union(ssv.state({ "travis matt": true }))
+    .diff({ "tom scott": true })
+    .union({ "travis matt": true })
     .$ === "mark travis matt"
+)
+assert.ok(
+  ssv("mark")
+    .xor({ "tom": true })
+    .xor({ "tom matt": true })
+    .$ === "mark matt"
+)
+assert.ok(
+  ssv("mark")
+    .meet({ "mark": true })
+    .concat({ "tom": false })
+    .$ === "mark"
+)
+assert.ok(
+  ssv().union({
+      "mark": true,
+      "tom scott": false,
+      "travis matt": true,
+    }).$ === "mark travis matt"
+)
+assert.ok(
+  ssv({ "mark tom scott": true })
+    .diff("scott")
+    .union("travis")
+    .diff("tom")
+    .union("matt")
+    .union(182)
+    .$ === "mark travis matt 182"
 )
 console.log("chaining tests passed")
 


### PR DESCRIPTION
This was an idea I had for enabling all methods to accept state objects. I like the concept for testing CSS states but it comes with some performance overhead and brain overload with methods like `diff` imo. It also drops support for `String` objects. My plan is to merge this but then tone it down to something better before the major release.

Slating all inputs like this would enable this syntax

```
ssv("mark tom scott").diff({ "tom scott": true })
```

But like I said I have a better idea. Gonna merge and work from here because I do like some of the code separation done with this PR