### PR TITLE
Add ssv.edit and tone down slate

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ ssv.state({
 - Count SSV values
 - `@return` number
 
+### `ssv.edit(SSV="", boss={})`
+- Edit an SSV string via an object
+- Keys for falsey values are removed
+- Keys for truthy values are added
+- Result is compact and unique
+- Optimal for editing CSS classes
+- `@return` string
+
 ### `ssv.diff(left="", right="")`
 - Get the difference of 2 SSV strings (values in first not present in second)
 - `@return` string
@@ -122,30 +130,24 @@ ssv.state({
 - Complement <var>set</var> with needed values from <var>more</var>
 - `@return` string
 
-### `ssv.slate(anything="")`
-- Get SSV string from anything
-- Used internally to normalize inputs
-- Uses `typeof` to determine type
-  - `string` returns as is
-  - `number|boolean|bigint` coerce to string
-  - `object|function` delegates to `ssv.swoop`
-  - `undefined|symbol` return `""`
-- Messy whitespace remains messy
+### `ssv.slate(unknown="")`
+- Convert unknown into string
+- `undefined|null` become `""`
 - `@return` string
 
 ### `ssv.split(set)`
 - Split <var>SSV</var> into compact array of values
 - `@return` array
 
-### `ssv.state(anything="")`
-- Get SSV string from <var>state</var> object or string
+### `ssv.state(state={})`
+- Get compact SSV string from state object or string
 - Useful for conditional classnames
 - `@return` string
 
-### `ssv.swoop(object={})`
-- Get SSV string from state object
-- Useful for conditional classnames object
-- Fast and loose
+### `ssv.swoop(state={})`
+- Get like-it-is SSV string from state object
+- `ssv.swoop` is the loop used by `ssv.state`
+- Provided for library developers or extreme optimization
 - `@return` string
 
 ### `ssv.union(left="", right="")`
@@ -166,7 +168,6 @@ Chaining offers all the static methods in chain syntax
 
 ### `ssv(set="")`
 - Create an `ssv` object instance
-- <var>set</var> defaults to an empty string
 - `@return` object
 
 #### Non-string returns are direct

--- a/ssv.d.ts
+++ b/ssv.d.ts
@@ -6,13 +6,14 @@ declare module ssv {
   export function compact(set: any): string;
   export function concat(set: any, more: any): string;
   export function count(set: any): number;
+  export function edit(set: any, boss: object): string;
   export function diff(set: any, less: any): string;
   export function meet(left: any, right: any): string;
   export function need(set: any, more: any): string;
   export function split(set: any): string[];
   export function slate(set: any): string;
   export function state(set: any): string;
-  export function swoop(set: any): string;
+  export function swoop(set: object): string;
   export function union(set: any, more: any): string;
   export function uniq(set: any): string;
   export function xor(left: any, right: any): string;

--- a/ssv.js
+++ b/ssv.js
@@ -10,6 +10,10 @@
   var space = " "
   var empty = ""
 
+  function slate(set) {
+    return null == set ? empty : empty + set
+  }
+
   function match(set) {
     return slate(set).match(word)
   }
@@ -113,36 +117,32 @@
     return s || empty
   }
 
-  function slate(set) {
-    set = set instanceof ssv ? set[$] : set
-    switch (typeof set) {
-      case "string":
-      return set
-      case "boolean":
-      case "bigint":
-      case "number":
-      return set + empty
-      case "function":
-      case "object":
-      return set ? swoop(set) : empty
-    } return empty
+  function edit(set, boss) {
+    var yes = empty
+    var noo = empty
+    for (var key in boss)
+      if (own.call(boss, key))
+        boss[key]
+          ? yes += space + key
+          : noo += space + key
+    set = noo ? diff(set, noo) : slate(set)
+    return yes ? uniq(set + space + yes) : set
   }
 
   function state(set) {
-    set = slate(set)
+    set = typeof set == "string" ? set : swoop(set)
     return set ? compact(set) : empty
   }
 
   /** @constructor */
   function ssv(set) {
     var o = this instanceof ssv ? this : new ssv
-    var f = set ? state : slate
-    o[$] = f(set)
+    o[$] = slate(set)
     return o
   }
 
   chain.toString = chain.valueOf = function() {
-    return this instanceof ssv ? slate(this) : empty
+    return this instanceof ssv ? slate(this[$]) : empty
   }
 
   function dot(f) {
@@ -166,6 +166,7 @@
   give(at)
   give(blank)
   give(compact)
+  give(edit)
   give(need)
   give(concat)
   give(count)

--- a/test.js
+++ b/test.js
@@ -181,8 +181,6 @@ console.log("#meet tests passed")
 assert.strictEqual(ssv.state(""), "")
 assert.strictEqual(ssv.state(" "), "")
 assert.strictEqual(ssv.state({}), "")
-assert.strictEqual(ssv.state(Symbol()), "")
-assert.strictEqual(ssv.state(Symbol("ignore")), "")
 assert.strictEqual(ssv.state(ssv.state("mark")), "mark")
 assert.strictEqual(ssv.state(ssv.state(" tom ")), "tom")
 assert.strictEqual(ssv.state(ssv.state(" mark matt ")), "mark matt")
@@ -204,6 +202,28 @@ assert.strictEqual(ssv.state({
   "travis": false
 }), "mark mark travis")
 console.log("#state tests passed")
+
+assert.strictEqual(ssv.edit(), "")
+assert.strictEqual(ssv.edit(182), "182")
+assert.strictEqual(ssv.edit(182, {}), "182")
+assert.strictEqual(ssv.edit("mark tom scott", {
+  "tom scott": false,
+  "travis matt": true
+}), "mark travis matt")
+assert.strictEqual(ssv.edit("mark tom scott", {
+  "scott scott": false,
+  "travis travis": true
+}), "mark tom travis")
+assert.strictEqual(ssv.edit("mark mark", {
+  "tom": true,
+}), "mark tom")
+assert.strictEqual(ssv.edit("mark tom scott", {
+  "scott": 0,
+  "travis": 1,
+  "tom": 0,
+  "matt": 1,
+}), "mark travis matt")
+console.log("#edit tests passed")
 
 assert.ok(ssv() instanceof ssv)
 assert.ok(ssv().$ === "")
@@ -231,7 +251,6 @@ assert.ok(ssv().count() === 0)
 assert.ok(ssv([]).$ === "")
 assert.ok(ssv(true).$ === "true")
 assert.ok(ssv(false).$ === "false")
-assert.ok(ssv([,"blink"]).$ === "1")
 assert.ok(ssv("mark tom scott").any("mark"))
 assert.ok(ssv("mark tom scott").count() === 3)
 assert.ok(ssv("mark tom scott").diff("scott").count() === 2)
@@ -251,32 +270,14 @@ assert.ok(
     .$ === "mark travis matt"
 )
 assert.ok(
-  ssv("mark tom scott")
-    .diff({ "tom scott": true })
-    .union({ "travis matt": true })
-    .$ === "mark travis matt"
-)
-assert.ok(
-  ssv("mark")
-    .xor({ "tom": true })
-    .xor({ "tom matt": true })
-    .$ === "mark matt"
-)
-assert.ok(
-  ssv("mark")
-    .meet({ "mark": true })
-    .concat({ "tom": false })
-    .$ === "mark"
-)
-assert.ok(
-  ssv().union({
+  ssv().edit({
       "mark": true,
       "tom scott": false,
       "travis matt": true,
     }).$ === "mark travis matt"
 )
 assert.ok(
-  ssv({ "mark tom scott": true })
+  ssv("mark tom scott")
     .diff("scott")
     .union("travis")
     .diff("tom")


### PR DESCRIPTION
Tone down the object slating from #70 and instead provide a new editing method optimal for CSS classes. This allows us to still support `String` instances everywhere and allows the object methods `edit` `state` `swoop` to handle any kinda object. I considered many ways for slating and handling objects and I think this is the best of all worlds 🤓 