### PR TITLE
Create immutable chaining technique

### DIFF
--- a/ssv.js
+++ b/ssv.js
@@ -4,7 +4,6 @@
 }(this, "ssv", function() {
 
   var $ = "$"
-  var chain = ssv.prototype
   var own = {}.hasOwnProperty
   var word = /\S+/g
   var space = " "
@@ -134,24 +133,24 @@
     return set ? compact(set) : empty
   }
 
-  /** @constructor */
+  function pod() {}
   function ssv(set) {
-    var o = this instanceof ssv ? this : new ssv
-    o[$] = slate(set)
-    return o
+    var fresh = new pod
+    fresh[$] = slate(set)
+    return fresh
   }
 
+  var chain = ssv.prototype = pod.prototype // proxy
+  chain.constructor = ssv // mask pod
   chain.toString = chain.valueOf = function() {
     return this instanceof ssv ? slate(this[$]) : empty
   }
 
-  function dot(f) {
+  function dot(fun) {
     return function(uno) {
-      var o = this instanceof ssv ? this : new ssv
-      var v = f(o[$], uno)
-      if (typeof v != "string") return v
-      o[$] = v
-      return o
+      var was = this instanceof ssv ? this[$] : empty
+      var got = fun(was, uno)
+      return typeof got == "string" ? ssv(got) : got
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -225,6 +225,7 @@ assert.strictEqual(ssv.edit("mark tom scott", {
 console.log("#edit tests passed")
 
 assert.ok(ssv() instanceof ssv)
+assert.ok(new ssv instanceof ssv)
 assert.ok(ssv.call() instanceof ssv)
 assert.ok(ssv().$ === "")
 assert.ok(ssv(undefined).$ === "")

--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
 var ssv = require("./")
 var assert = require("assert")
 
-
 assert.strictEqual(ssv.split("").length, 0)
 assert.strictEqual(ssv.split(" ").length, 0)
 assert.strictEqual(ssv.split("mark").join("-"), "mark")
@@ -226,13 +225,21 @@ assert.strictEqual(ssv.edit("mark tom scott", {
 console.log("#edit tests passed")
 
 assert.ok(ssv() instanceof ssv)
+assert.ok(ssv.call() instanceof ssv)
 assert.ok(ssv().$ === "")
 assert.ok(ssv(undefined).$ === "")
 assert.ok(ssv(null).$ === "")
 assert.ok(ssv("182").$ === "182")
 assert.ok(ssv(182).$ === "182")
 assert.ok(ssv().hasOwnProperty("$"))
+assert.ok(ssv().constructor === ssv)
 console.log("constructor tests passed")
+
+var mark = ssv("mark")
+var nark = ssv()
+assert.ok(mark.diff("mark") !== mark)
+assert.ok(ssv.call(nark) !== nark)
+console.log("immutable tests passed")
 
 assert.ok(String(ssv(182)) === "182")
 assert.ok(ssv(182).toString() === "182")


### PR DESCRIPTION
This uses a private proxy constructor named `pod` to ensure that there's no way to call `ssv` or any chain methods in way that mutates an object. Every time you chain you get a new ssv instance.