### PR TITLE
Correct or example

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ ssv.or(left="", right="")
 ```
 
 ```js
-ssv.union("mark tom ", "travis tom") // "mark tom travis"
-ssv.union("mark tom tom", "travis tom") // "mark tom travis"
-ssv.union("matt mark", "matt") // "matt mark"
+ssv.or("mark tom ", "travis tom") // "mark tom travis"
+ssv.or("mark tom tom", "travis tom") // "mark tom travis"
+ssv.or("matt mark", "matt") // "matt mark"
 ```
 
 ### `say`


### PR DESCRIPTION
missed replacement when renaming `ssv.union` to `ssv.or`