### PR TITLE
Remove swoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ const ssv = require("ssv")
 - [`ssv.or`](#or)
 - [`ssv.say`](#say)
 - [`ssv.split`](#split)
-- [`ssv.swoop`](#swoop)
 - [`ssv.xor`](#xor)
 - [`ssv.yolo`](#yolo)
 
@@ -239,7 +238,7 @@ ssv.say(new Boolean(true), "true")
 - Used internally when expecting strings
 - Not intended for arrays or plain objects
 - Join arrays instead like `[].join(" ")`
-- Plain objects may use [`ssv.edit`](#edit) [`ssv.state`](#state) [`ssv.swoop`](#swoop)
+- Plain objects may use [`ssv.edit`](#edit) or [`ssv.state`](#state)
 
 ### `split`
 
@@ -281,23 +280,6 @@ ssv.state({
   "mark travis": true,
   "travis": false
 }) // "mark mark travis"
-```
-
-### `swoop`
-
-- Get like-it-is SSV string from state object
-- `ssv.swoop` is the loop used by `ssv.state`
-- Provided for library developers or extreme optimization
-
-```js
-ssv.swoop(state={})
-```
-
-```js
-ssv.swoop({
-  "  mark  mark ": true,
-  "  tom": false
-}) // "  mark  mark "
 ```
 
 ### `xor`

--- a/ssv.d.ts
+++ b/ssv.d.ts
@@ -13,7 +13,6 @@ declare module ssv {
   export function say(set: any): string;
   export function split(set: any): string[];
   export function state(set: any): string;
-  export function swoop(set: object): string;
   export function xor(left: any, right: any): string;
   export function yolo(set: any): string;
 }

--- a/ssv.js
+++ b/ssv.js
@@ -104,14 +104,6 @@
     return d
   }
 
-  function swoop(set) {
-    var s
-    for (var key in set)
-      if (own.call(set, key) && set[key])
-        s ? s += space + key : s = key
-    return s || empty
-  }
-
   function edit(set, boss) {
     var yes = empty
     var noo = empty
@@ -126,9 +118,10 @@
     return !yes || eco ? yolo(set) : or(set, yes)
   }
 
-  function state(set) {
-    set = typeof set == "string" ? set : swoop(set)
-    return set ? yolo(set) : empty
+  function state(set) { 
+    return typeof set == "string"
+      ? set ? yolo(set) : empty
+      : edit(empty, set)
   }
 
   function give(f) {
@@ -150,7 +143,6 @@
   give(say)
   give(split)
   give(state)
-  give(swoop)
   give(xor)
   give(yolo)
 


### PR DESCRIPTION
Remove `ssv.swoop` and change `state` to reuse `edit` instead of `swoop` 
