### PR TITLE
Reduce speculative links

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
 <link rel="icon" href="icon.svg">
 <link rel="stylesheet" href="index.css">
 <link rel="canonical" href="https://ryanve.github.io/ssv/">
-<link rel="preconnect" href="https://github.com" crossorigin>
-<link rel="prefetch" href="https://github.com/ryanve/ssv/blob/master/README.md" crossorigin>
-<link rel="prefetch" href="https://github.com/sponsors/ryanve" crossorigin>
+<link rel="preconnect" href="https://github.com">
+<link rel="prefetch" href="https://github.com/ryanve/ssv/blob/master/README.md">
+<link rel="prefetch" href="https://github.com/sponsors/ryanve">
 
 <h1><a href="https://ryanve.github.io/ssv/"><code>ssv</code></a></h1>
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,6 @@
 <link rel="stylesheet" href="index.css">
 <link rel="canonical" href="https://ryanve.github.io/ssv/">
 <link rel="preconnect" href="https://github.com">
-<link rel="prefetch" href="https://github.com/ryanve/ssv/blob/master/README.md">
-<link rel="prefetch" href="https://github.com/sponsors/ryanve">
 
 <h1><a href="https://ryanve.github.io/ssv/"><code>ssv</code></a></h1>
 


### PR DESCRIPTION
Having [`crossorigin`](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes) caused Chrome to block them due to `github.com` CORS policy

```
No 'Access-Control-Allow-Origin'
```

I removed the [`prefetch`](https://w3c.github.io/resource-hints/#prefetch) links because they caused Chrome to warned that `github.com` was setting a cookie. Seems best to avoid console warnings and speculated cookies.

[Learn about speculative links](https://github.com/ryanve/speculative#rel)