### PR TITLE
Optimize and

### DIFF
--- a/ssv.js
+++ b/ssv.js
@@ -75,7 +75,7 @@
 
   function and(left, right) {
     return not(
-      or(left, right),
+      yolo(left),
       xor(left, right))
   }
 


### PR DESCRIPTION
Simplify operation needed for [`ssv.and`](https://github.com/ryanve/ssv/blob/v4.0.1/README.md#and) while still reusing existing code. I chose the middle way after sampling 3 ways in node 12 with [lap](https://github.com/ryanve/lap)

#### 366 ops/ms

```js
// original way
return not(
  or(left, left),
  xor(left, right))
```

#### 458 ops/ms

```js
// faster and terser
return not(
  yolo(left),
  xor(left, right))
```

#### 545 ops/ms

```js
// fastest but trippy
return not(
  yolo(left),
  not(left, right) + space +
  not(right, left))
```

#### sample operation

```js
ssv.and("mark tom travis", "tom scott travis")
```