### PR TITLE
Refactor any

### DIFF
--- a/ssv.js
+++ b/ssv.js
@@ -31,20 +31,7 @@
   }
 
   function any(set, search) {
-    search = split(search)
-    var l = search.length
-    if (!l) return false
-    set = split(set)
-    var n = set.length
-    var j = 0
-    while (j < n) {
-      var i = l
-      var v = set[j++]
-      while (i--)
-        if (v === search[i])
-          return true
-    }
-    return false
+    return count(not(set, search)) < count(set)
   }
 
   function all(set, search) {


### PR DESCRIPTION
Handle [`ssv.any`](https://github.com/ryanve/ssv/blob/v4.0.1/README.md#any) with code reuse at some speed cost but with 32B overall code savings. A even terser way to do this would be [`!!and(set, search)`](https://github.com/ryanve/ssv/blob/v4.0.1/README.md#and) but that's slower because it does much more than what `any` needs. I sampled 3 ways in node 12 using [`lap`](https://github.com/ryanve/lap)

```js
ssv.any("mark tom travis", "tom scott travis")
```

- 2200 ops/ms for original loop that returns `true` as soon as it sees `"tom"`
- 1310 ops/ms for `count` way I chose
- 452 ops/ms for `and` way