### PR TITLE
URL deets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+permalink: pretty
+plugins:
+  - jekyll-sitemap


### PR DESCRIPTION
- Use sitemap to tell Github to have it public in Google
- `permalink: pretty` would change `page.html` to `page/` if page was added