### PR TITLE
Link in funny order

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
 <meta name="theme-color" content="WhiteSmoke">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Practice using ssv online from anywhere in space.">
-<link rel="icon" href="icon.svg">
 <link rel="stylesheet" href="index.css">
-<link rel="canonical" href="https://ryanve.github.io/ssv/">
 <link rel="help" href="https://github.com/ryanve/ssv/blob/master/README.md">
+<link rel="icon" href="icon.svg">
 <link rel="preconnect" href="https://github.com">
+<link rel="canonical" href="https://ryanve.github.io/ssv/">
 
 <h1><a href="https://ryanve.github.io/ssv/"><code>ssv</code></a></h1>
 <p><dfn>ssv</dfn> is universal


### PR DESCRIPTION
Sort head links [online](https://ryanve.github.io/ssv/) to spell downward lol

I could spell `chips` but chose `shipc` to fit space theme and they seem harder to misclick this way if you aim near the ends