### PR TITLE
Phase out node 10 test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [12, 14]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
[`ssv.js`](https://github.com/ryanve/ssv/blob/master/ssv.js) uses no code anyway that would differ in node 10

[node 14 become LTS in October 2020](https://link.medium.com/V1M6y5AUR5)